### PR TITLE
Add numpy compatibility aliases for deprecated types

### DIFF
--- a/Python/stereo_needle_proc.py
+++ b/Python/stereo_needle_proc.py
@@ -19,6 +19,14 @@ from typing import Union
 import cv2 as cv
 import matplotlib.pyplot as plt
 import numpy as np
+
+# Compatibility aliases for deprecated NumPy scalar types
+if not hasattr(np, "float"):
+    np.float = float
+if not hasattr(np, "int"):
+    np.int = int
+if not hasattr(np, "bool"):
+    np.bool = bool
 import scipy.io as sio
 # NURBS
 from geomdl import fitting


### PR DESCRIPTION
## Summary
- add runtime compatibility aliases for deprecated NumPy scalar types when missing

## Testing
- `python -c "import sys; sys.path.append('Python'); import stereo_needle_proc"` *(fails: ModuleNotFoundError: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_68d593642210832e85b7e66082b04522