### PR TITLE
Update MATLAB stereo needle processing to use Python reference reconstruction

### DIFF
--- a/MATLAB/stereo_needle_proc.m
+++ b/MATLAB/stereo_needle_proc.m
@@ -29,6 +29,7 @@ None = py.None;
 % directories for files
 stereo_param_dir = '../../Stereo_Camera_Calibration_10-23-2020/';
 stereo_needle_dir = '../../Test Images/stereo_needle/needle_examples/';
+stereo_reference_dir = '../../Test Images/stereo_needle/reference_frames/';
 stereo_param_cvfile = stereo_param_dir + "calibrationSession_params-error_opencv-struct.mat";
 stereo_param_file = stereo_param_dir + "calibrationSession_params-error.mat";
 
@@ -40,32 +41,33 @@ stereo_params_py = py.stereo_needle_proc.load_stereoparams_matlab(stereo_param_c
 % read in the images
 num = 6;
 file_base = "%s-%04d.png";
+ref_file_base = "%s_ref-%04d.png";
 
 l_img_file = stereo_needle_dir + sprintf(file_base, 'left', num);
 r_img_file = stereo_needle_dir + sprintf(file_base, 'right', num);
+l_ref_img_file = stereo_reference_dir + sprintf(ref_file_base, 'left', num);
+r_ref_img_file = stereo_reference_dir + sprintf(ref_file_base, 'right', num);
 
 l_img = imread(l_img_file);
 r_img = imread(r_img_file);
+l_ref_img = imread(l_ref_img_file);
+r_ref_img = imread(r_ref_img_file);
 
 needle_proc(l_img, r_img)
 
 % stereo needle processing
 roi_l = py.tuple({{int16(70), int16(80)}, {int16(500), int16(915)}});
-roi_r = py.tuple({{int16(70), int16(55)}, {int16(500), int16(-1)}}); 
-res = py.stereo_needle_proc.needleproc_stereo(py.numpy.array(l_img), py.numpy.array(r_img),...
-                                              py.list(), py.list(), roi_l, roi_r);                
-left_skel = boolean(res{1});
-right_skel = boolean(res{2});
-conts_l = res{3};
-conts_r = res{4};
+roi_r = py.tuple({{int16(70), int16(55)}, {int16(500), int16(-1)}});
+res = py.stereo_needle_proc.needle_reconstruction_ref(py.numpy.array(l_img),...
+                                                      py.numpy.array(l_ref_img),...
+                                                      py.numpy.array(r_img),...
+                                                      py.numpy.array(r_ref_img),...
+                                                      stereo_params_py, py.list(),...
+                                                      py.list(), roi_l, roi_r);
 
-% perform contour matching
-res = py.stereo_needle_proc.stereomatch_needle(conts_l{1}, conts_r{1});
-cont_l_match = squeeze(double(res{1}));
-cont_r_match = squeeze(double(res{2}));
-
-%% 3-D Reconstruction
-needle_3d = triangulate_stereomatch(cont_l_match, cont_r_match, stereo_params);
+needle_3d = double(res{1}(:, 1:3));
+cont_l_match = double(res{2});
+cont_r_match = double(res{3});
 
 plot3(needle_3d(:,1), needle_3d(:,2), needle_3d(:,3));
 axis equal; grid on;


### PR DESCRIPTION
## Summary
- add configuration for reference image paths when running the MATLAB stereo needle wrapper
- load corresponding left/right reference frames for each capture
- invoke the Python `needle_reconstruction_ref` routine and convert its results back to MATLAB for plotting

## Testing
- not run (MATLAB script changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d5ac8838e8832e90a361c7de615b03