### PR TITLE
Remove obsolete needle_proc invocation

### DIFF
--- a/MATLAB/stereo_needle_proc.m
+++ b/MATLAB/stereo_needle_proc.m
@@ -52,9 +52,6 @@ l_img = imread(l_img_file);
 r_img = imread(r_img_file);
 l_ref_img = imread(l_ref_img_file);
 r_ref_img = imread(r_ref_img_file);
-
-needle_proc(l_img, r_img)
-
 % stereo needle processing
 roi_l = py.tuple({{int16(70), int16(80)}, {int16(500), int16(915)}});
 roi_r = py.tuple({{int16(70), int16(55)}, {int16(500), int16(-1)}});


### PR DESCRIPTION
## Summary
- remove the stray `needle_proc` call from the MATLAB wrapper so execution reaches the stereo reconstruction bridge

## Testing
- not run (MATLAB is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d5ad68db2c832ebb34f22d4845f4e8